### PR TITLE
Fix GitHub Actions deployment by creating docs directory

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,3 +31,9 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./dist
+
+      - name: Create docs directory
+        run: mkdir -p docs
+
+      - name: Update Jekyll configuration
+        run: echo "source: docs" >> _config.yml


### PR DESCRIPTION
Update GitHub Actions workflow to fix deployment failure due to missing directory error in Jekyll build process.

* Add a step to create the `docs` directory before the Jekyll build process.
* Update Jekyll configuration to set the source directory to `docs`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/schuanhe/job-timer/pull/1?shareId=4155f010-a273-4083-b634-ecde2321ce3e).